### PR TITLE
Support for Xcode16

### DIFF
--- a/sentry_client_cocoa.podspec
+++ b/sentry_client_cocoa.podspec
@@ -12,6 +12,6 @@ Pod::Spec.new do |s|
 
   s.ios.vendored_frameworks = 'sentry_client_cocoa.xcframework'
 
-  s.dependency 'Sentry', '8.30.0'
+  s.dependency 'Sentry', '8.36.0'
 
   end

--- a/sentry_client_cocoa.podspec
+++ b/sentry_client_cocoa.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'sentry_client_cocoa'
-  s.version          = '4.0.1'
+  s.version          = '4.0.2'
   s.summary          = 'sentry_client_cocoa is intended to sanitize the data before sending to the Sentry servers'
 
   s.homepage         = 'https://github.com/lyra/sentry-client-cocoa'


### PR DESCRIPTION
Hello everyone!

## Problem
In my project, one of my dependencies is the pod [LyraPaymentSDK](https://cocoapods.org/pods/LyraPaymentSDK), which depends on this project. I recently upgraded my Xcode to Xcode 16 and found out that I couldn't build iOS apps anymore. 
This is because of [this issue](https://github.com/getsentry/sentry-cocoa/pull/4244) : Sentry below v3.33.0 doesn't work with Xcode 16 😢
So I would need the dependency to Sentry to be bumped, so that the pod [LyraPaymentSDK](https://cocoapods.org/pods/LyraPaymentSDK) can then be updated too 

## what I did in this PR
- Bumped Sentry to 3.36.0 (3.33.0 would fill my needs but I took the last existing version)
- Updated the pod's version to 4.0.2

### points of attention
- I'm not sure I could properly test the behavior with this new version of Sentry, please be careful while reviewing or indicate some steps to test this
- I didn't update any changelog, I don't know what are your standards here, but I would gladly do it if you provide some more info

Don't hesitate to give me some feedback if you see something I missed, or handle this bump in an other branch and close this PR if it's easier for you 😁

Closes https://github.com/lyra/sentry-client-cocoa/issues/1
